### PR TITLE
Fix the issue that buttons don't work on iOS

### DIFF
--- a/src/styles.less
+++ b/src/styles.less
@@ -473,17 +473,23 @@ footer {
 
 // Animations
 @keyframes fade-in {
-	from { opacity:0; }
-	to { opacity:1; }
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+		// This fixes the issue in https://stackoverflow.com/questions/5472802
+		transform: translate3d(0, 0, 0);
+	}
 }
 
 @keyframes fade-in-up {
 	from {
-		opacity:0;
+		opacity: 0;
 		transform: translateY(100px) rotate3d(0, 0, 1, 8deg);
 	}
 	to {
-		opacity:1;
+		opacity: 1;
 		transform: none;
 	}
 }


### PR DESCRIPTION
Buttons on the top page don't work on iOS due to the css z-index problem. See https://stackoverflow.com/questions/5472802/css-z-index-lost-after-webkit-transform-translate3d.

This fixes chartjs/Chart.js#5774.