### PR TITLE
Include typedoc class docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 include:
-  - "_*_.html"
+  - "_*.html"


### PR DESCRIPTION
https://www.chartjs.org/docs/master/typedoc/classes/_controllers_controller_bar_.barcontroller.html doesn't have an underscore before the ".html"