### PR TITLE
Add `lang` to homepage

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 
 	<head>
 		<title>{% block title %}{% endblock title %}</title>


### PR DESCRIPTION
While I was getting working on #20, I ran Lighthouse accessibility scans to make sure I had gotten all of the images. I had, but Lighthouse flagged the fact that there was no `lang` attribute on the page's HTML. It was a minor thing, but not exactly related to alt text, so I'm making another PR. If you need me to open an issue for it, I can.

I chose the language `en-US` because, well, it's in `en`glish, and it says "color", so that feels `US`-y. I can change it if you'd prefer a different language code.